### PR TITLE
Return directly if GTEST_FOUND and GMOCK_FOUND were already set.

### DIFF
--- a/FindGoogleMock.cmake
+++ b/FindGoogleMock.cmake
@@ -57,6 +57,13 @@ option (GTEST_PREFER_SOURCE_BUILD
 option (GMOCK_PREFER_SOURCE_BUILD
         "Whether or not to prefer a source build of Google Mock." OFF)
 
+# Situation 0. Google Test and Google Mock were already found. Use those
+if (GTEST_FOUND AND GMOCK_FOUND)
+
+    return ()
+
+endif (GTEST_FOUND AND GMOCK_FOUND)
+
 # Situation 1. Google Test and Google Mock are shipped in library form.
 # Use the libraries unless there we've been asked not to.
 if (NOT GTEST_PREFER_SOURCE_BUILD)


### PR DESCRIPTION
We might be in a superproject which has already built Google Test
and Google Mock. No need to build it twice.
