### PR TITLE
Typo fixes and fix importing from external project and build on ubuntu.

### DIFF
--- a/FindGoogleMock.cmake
+++ b/FindGoogleMock.cmake
@@ -210,44 +210,50 @@ endfunction (_find_prefix_from_base)
 # Test was, and it is acceptable to use Google Mock in library form.
 if (NOT GTEST_FOUND AND NOT GMOCK_FOUND AND NOT GMOCK_PREFER_SOURCE_BUILD)
 
-    # Find the the Google Test include directory
-    # by searching the system-wide include directory
-    # paths
-    find_path (GTEST_INCLUDE_DIR
-               gtest/gtest.h)
+    # Google Mock must be found in library form first, otherwise
+    # we end up calling add_subdirectory twice.
+    find_library (GMOCK_LIBRARY gmock)
+    find_library (GMOCK_MAIN_LIBRARY gmock_main)
 
-    if (GTEST_INCLUDE_DIR)
+    if (GMOCK_LIBRARY AND GMOCK_MAIN_LIBRARY)
 
-        set (GTEST_INCLUDE_BASE "include/")
-        _find_prefix_from_base (${GTEST_INCLUDE_BASE}
-                                ${GTEST_INCLUDE_DIR}
-                                GTEST_INCLUDE_PREFIX)
+        # Find the the Google Test include directory
+        # by searching the system-wide include directory
+        # paths
+        find_path (GTEST_INCLUDE_DIR
+                   gtest/gtest.h)
 
-        find_path (GTEST_SRC_DIR
-                   CMakeLists.txt
-                   PATHS ${GTEST_INCLUDE_PREFIX}/src/gtest
-                   NO_DEFAULT_PATH)
+        if (GTEST_INCLUDE_DIR)
 
-        if (GTEST_SRC_DIR)
+            set (GTEST_INCLUDE_BASE "include/")
+            _find_prefix_from_base (${GTEST_INCLUDE_BASE}
+                                    ${GTEST_INCLUDE_DIR}
+                                    GTEST_INCLUDE_PREFIX)
 
-            add_subdirectory (${GTEST_SRC_DIR}
-                              ${CMAKE_CURRENT_BINARY_DIR}/src/gtest)
+            find_path (GTEST_SRC_DIR
+                       CMakeLists.txt
+                       PATHS ${GTEST_INCLUDE_PREFIX}/src/gtest
+                       NO_DEFAULT_PATH)
 
-            set (GTEST_CREATED_TARGET TRUE)
+            if (GTEST_SRC_DIR)
 
-            find_library (GMOCK_LIBRARY gmock)
-            find_library (GMOCK_MAIN_LIBRARY gmock_main)
+                message ("Adding GTest subdirectory")
+                add_subdirectory (${GTEST_SRC_DIR}
+                                  ${CMAKE_CURRENT_BINARY_DIR}/src/gtest)
 
-            if (GMOCK_LIBRARY AND GMOCK_MAIN_LIBRARY)
+                set (GTEST_CREATED_TARGET TRUE)
+
+                find_library (GMOCK_LIBRARY gmock)
+                find_library (GMOCK_MAIN_LIBRARY gmock_main)
 
                 set (GTEST_FOUND TRUE)
                 set (GMOCK_FOUND TRUE)
 
-            endif (GMOCK_LIBRARY AND GMOCK_MAIN_LIBRARY)
+            endif (GTEST_SRC_DIR)
 
-        endif (GTEST_SRC_DIR)
+        endif (GTEST_INCLUDE_DIR)
 
-    endif (GTEST_INCLUDE_DIR)
+    endif (GMOCK_LIBRARY AND GMOCK_MAIN_LIBRARY)
 
 endif (NOT GTEST_FOUND AND NOT GMOCK_FOUND AND NOT GMOCK_PREFER_SOURCE_BUILD)
 
@@ -281,6 +287,7 @@ if (NOT GMOCK_ALWAYS_DOWNLOAD_SOURCES)
                 set (GMOCK_INCLUDE_DIR ${GMOCK_INCLUDE_DIR})
                 set (GTEST_INCLUDE_DIR ${GMOCK_SRC_DIR}/gtest/include)
 
+                message ("adding GMock subdirectory")
                 add_subdirectory (${GMOCK_SRC_DIR}
                                   ${CMAKE_CURRENT_BINARY_DIR}/src/gmock)
 

--- a/GoogleMockLibraryUtils.cmake
+++ b/GoogleMockLibraryUtils.cmake
@@ -9,11 +9,11 @@ include (imported-project-utils/ImportedProjectUtils)
 
 macro (_google_mock_append_dependencies LIBRARY DEPENDENCIES)
 
-    if (TARGET ${${LIBRARY}})
+    if (TARGET ${LIBRARY})
 
-        list (APPEND ${DEPENDENCIES} ${${LIBRARY}})
+        list (APPEND ${DEPENDENCIES} ${LIBRARY})
 
-    endif (TARGET ${${LIBRARY}})
+    endif (TARGET ${LIBRARY})
 
 endmacro (_google_mock_append_dependencies)
 
@@ -21,8 +21,7 @@ macro (_google_mock_append_cache_library_path CACHE_OPTION
                                               LIBRARY
                                               CACHE_LINES)
 
-    polysquare_import_utils_get_library_location_from_variable (${LIBRARY}
-                                                                RESULT)
+    polysquare_import_utils_get_library_location (${LIBRARY} RESULT)
     polysquare_import_utils_append_cache_definition (${CACHE_OPTION}
                                                      ${RESULT}
                                                      ${CACHE_LINES})
@@ -32,11 +31,11 @@ endmacro (_google_mock_append_cache_library_path)
 macro (_google_mock_append_extproject_variables LIBRARY
                                                 CACHE_ARGUMENT_LINE
                                                 DEPENDENCIES
-                                                CACHE_OPTION)
+                                                CACHE_LINES)
 
-    _google_mock_append_cache_library_path (${CACHE_OPTION}
+    _google_mock_append_cache_library_path (${CACHE_ARGUMENT_LINE}
                                             ${LIBRARY}
-                                            ${CACHE_ARGUMENT_LINE})
+                                            ${CACHE_LINES})
     _google_mock_append_dependencies (${LIBRARY} ${DEPENDENCIES})
 
 endmacro (_google_mock_append_extproject_variables)
@@ -64,25 +63,25 @@ function (google_mock_get_cache_lines_and_deps_from_found CACHE_LINES
     set (EXTERNAL_PROJECT_CACHE_DEFINITIONS)
     set (EXTERNAL_PROJECT_DEPENDENCIES)
     polysquare_import_utils_append_cache_definition (GTEST_EXTERNAL_SET_INCLUDE_DIR
-                                                     GTEST_INCLUDE_DIR
+                                                     ${GTEST_INCLUDE_DIR}
                                                      EXTERNAL_PROJECT_CACHE_DEFINITIONS)
     polysquare_import_utils_append_cache_definition (GMOCK_EXTERNAL_SET_INCLUDE_DIR
-                                                     GMOCK_INCLUDE_DIR
+                                                     ${GMOCK_INCLUDE_DIR}
                                                      EXTERNAL_PROJECT_CACHE_DEFINITIONS)
 
-    _google_mock_append_extproject_variables (GTEST_LIBRARY
+    _google_mock_append_extproject_variables (${GTEST_LIBRARY}
                                               GTEST_EXTERNAL_SET_LIBRARY
                                               EXTERNAL_PROJECT_DEPENDENCIES
                                               EXTERNAL_PROJECT_CACHE_DEFINITIONS)
-    _google_mock_append_extproject_variables (GMOCK_LIBRARY
+    _google_mock_append_extproject_variables (${GMOCK_LIBRARY}
                                               GMOCK_EXTERNAL_SET_LIBRARY
                                               EXTERNAL_PROJECT_DEPENDENCIES
                                               EXTERNAL_PROJECT_CACHE_DEFINITIONS)
-    _google_mock_append_extproject_variables (GTEST_MAIN_LIBRARY
+    _google_mock_append_extproject_variables (${GTEST_MAIN_LIBRARY}
                                               GTEST_EXTERNAL_SET_MAIN_LIBRARY
                                               EXTERNAL_PROJECT_DEPENDENCIES
                                               EXTERNAL_PROJECT_CACHE_DEFINITIONS)
-    _google_mock_append_extproject_variables (GMOCK_MAIN_LIBRARY
+    _google_mock_append_extproject_variables (${GMOCK_MAIN_LIBRARY}
                                               GMOCK_EXTERNAL_SET_MAIN_LIBRARY
                                               EXTERNAL_PROJECT_DEPENDENCIES
                                               EXTERNAL_PROJECT_CACHE_DEFINITIONS)

--- a/test/FromParentInExternalProject.cmake
+++ b/test/FromParentInExternalProject.cmake
@@ -42,10 +42,12 @@ set (PROJECT_DEPENDENCIES)
 google_mock_get_cache_lines_and_deps_from_found (CACHE_DEFINITIONS
                                                  PROJECT_DEPENDENCIES)
 
+message ("CACHE: ${CACHE_DEFINITIONS}")
+
 ExternalProject_Add (ExternalLibraryUsingGTest
 	                 SOURCE_DIR ${EXTERNAL_PROJECT_DIRECTORY}
 	                 BINARY_DIR ${EXTERNAL_PROJECT_BINARY_DIRECTORY}
-	                 CMAKE_CACHE_ARGS ${EXTERNAL_PROJECT_CACHE_DEFINITIONS}
+	                 CMAKE_CACHE_ARGS ${CACHE_DEFINITIONS}
 	                 INSTALL_COMMAND "")
 
 add_dependencies (ExternalLibraryUsingGTest


### PR DESCRIPTION
We were calling add_subdirectory twice due to searching for GTest first.

We were also passing the wrong arguments to `_google_mock_append_extproject_variables`
